### PR TITLE
fix: correct Quill editor layout and dark-mode styling

### DIFF
--- a/e2e/.auth/state.json
+++ b/e2e/.auth/state.json
@@ -2,7 +2,7 @@
   "cookies": [
     {
       "name": "AUTH_SESSION_ID",
-      "value": "YzA4Njk2N2QtNjQ1YS00N2JmLWIyNzEtNmE4OWY5MmQyOTU5Lm9aNGdnV0N3ZTZvS19MVV9PSkEyZG5oR2gyS0hjOGNsZ0NsNnBoSF9wMVdta0ZCa1VXTTZMMURmYWFvXzhWM2tLdVJObGFVNF9ZZC03dkU3UVA5WWRB",
+      "value": "ODcwODAwN2MtOTUzYy00OTliLTg2NjktZjVjZGFhNDZhOGY1LjFZQ0I2WS1GaEFSdW9QcGV0UzFkRDh2ZGdUbHB5Z0tJVHFjX05FeVNGRlNkWUM0elJVaFBoS3IxeTRfOTQxamgyMzJYa0Q1OEVGRGxnMExyYjFHZnZ3",
       "domain": "localhost",
       "path": "/realms/platform-admin/",
       "expires": -1,
@@ -12,17 +12,17 @@
     },
     {
       "name": "KC_AUTH_SESSION_HASH",
-      "value": "Q37H1aJ+zSwUpdzWzdNACTuj1ipqAhafLwnDfP1DLp0",
+      "value": "\"PydbmwmBTrdfjVKOdl5jtxvTYtGXTj/d5TvgICq+sF0\"",
       "domain": "localhost",
       "path": "/realms/platform-admin/",
-      "expires": 1785849690.042572,
+      "expires": 1785865519.512121,
       "httpOnly": false,
       "secure": true,
       "sameSite": "None"
     },
     {
       "name": "KEYCLOAK_IDENTITY",
-      "value": "eyJhbGciOiJIUzUxMiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0MDkyY2IxMy1hMDY4LTQ0YmUtOTJmOS02N2MxYzE3Y2U5ZTAifQ.eyJleHAiOjE3ODU4ODU2MzAsImlhdCI6MTc4NTg0OTYzMCwianRpIjoiOGQyYjRlNWQtNzAyYS02ZDYxLTc3M2QtNzE4NmVkYzRlYmQxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgyL3JlYWxtcy9wbGF0Zm9ybS1hZG1pbiIsInN1YiI6IjU1YmJlNmM4LWE2OGEtNGYxMC1hMjg4LWY1ZGQyMDhiNjNiMiIsInR5cCI6IlNlcmlhbGl6ZWQtSUQiLCJzaWQiOiJjMDg2OTY3ZC02NDVhLTQ3YmYtYjI3MS02YTg5ZjkyZDI5NTkiLCJzdGF0ZV9jaGVja2VyIjoiMUlLRU1CSTFZZkpQNE1qYzlMaXFtNjhvNGY2blEwRGszYjZmUkpaV0pOOCJ9.0ax00k6a-YbOzW4L19gds8mXDjXAAJdndqWBEXENufii8sJh7zhzRUU8Q3c4s33KNb_aoUInUy5NgVlCavC8gg",
+      "value": "eyJhbGciOiJIUzUxMiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0MDkyY2IxMy1hMDY4LTQ0YmUtOTJmOS02N2MxYzE3Y2U5ZTAifQ.eyJleHAiOjE3ODU5MDE0NTksImlhdCI6MTc4NTg2NTQ1OSwianRpIjoiOTE3YjEyNjQtNjI5Zi02NjRiLTFjZmEtMGQyNTkxMGY0MDIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgyL3JlYWxtcy9wbGF0Zm9ybS1hZG1pbiIsInN1YiI6IjU1YmJlNmM4LWE2OGEtNGYxMC1hMjg4LWY1ZGQyMDhiNjNiMiIsInR5cCI6IlNlcmlhbGl6ZWQtSUQiLCJzaWQiOiI4NzA4MDA3Yy05NTNjLTQ5OWItODY2OS1mNWNkYWE0NmE4ZjUiLCJzdGF0ZV9jaGVja2VyIjoiNVl1LWtkU3VUUkVzdnB0VXltSFJKMHVaWTljaW90ZVJSd1FNQ3E4SWNGTSJ9.Oo5f_1BYZ_7o_RTWYxiBYbMf2JFx_0DjdbvBnE5GmU1c9YfdUsiMJ2w5_N9_BUm4IqFTu3PP08T8AO3wZqKggg",
       "domain": "localhost",
       "path": "/realms/platform-admin/",
       "expires": -1,
@@ -32,10 +32,10 @@
     },
     {
       "name": "KEYCLOAK_SESSION",
-      "value": "Q37H1aJ-zSwUpdzWzdNACTuj1ipqAhafLwnDfP1DLp0",
+      "value": "PydbmwmBTrdfjVKOdl5jtxvTYtGXTj_d5TvgICq-sF0",
       "domain": "localhost",
       "path": "/realms/platform-admin/",
-      "expires": 1785885630.223145,
+      "expires": 1785901459.670065,
       "httpOnly": false,
       "secure": true,
       "sameSite": "None"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -224,6 +224,51 @@ li {
   color: var(--brand-text);
 }
 
+/* Quill (ngx-quill) rich-text editor — the host element defaults to inline-block with
+   baseline vertical-align, which puts it on the same line as a preceding <label> and makes the
+   label appear pinned near the editor's bottom edge instead of stacked above it. */
+quill-editor {
+  display: block;
+  width: 100%;
+}
+
+:root.dark-mode .ql-toolbar.ql-snow,
+:root.dark-mode .ql-container.ql-snow {
+  background-color: var(--brand-border);
+  border-color: var(--brand-border);
+}
+
+:root.dark-mode .ql-editor {
+  color: var(--brand-text);
+}
+
+:root.dark-mode .ql-editor.ql-blank::before {
+  color: var(--brand-muted);
+}
+
+:root.dark-mode .ql-snow .ql-stroke,
+:root.dark-mode .ql-snow .ql-stroke-miter {
+  stroke: var(--brand-text);
+}
+
+:root.dark-mode .ql-snow .ql-fill,
+:root.dark-mode .ql-snow .ql-stroke.ql-fill {
+  fill: var(--brand-text);
+}
+
+:root.dark-mode .ql-snow .ql-picker {
+  color: var(--brand-text);
+}
+
+:root.dark-mode .ql-snow .ql-picker-options {
+  background-color: var(--brand-border);
+  border-color: var(--brand-muted);
+}
+
+:root.dark-mode .ql-snow .ql-picker.ql-expanded .ql-picker-label {
+  border-color: var(--brand-muted);
+}
+
 /* Dark mode alert styling */
 :root.dark-mode .alert {
   background-color: var(--brand-border);


### PR DESCRIPTION
quill-editor defaults to inline-block with baseline vertical-align, which put it on the same line as its preceding <label> and pinned the label near the editor's bottom edge instead of stacking above it. Also adds :root.dark-mode overrides for the editor/toolbar, since Quill's snow theme has no dark-mode awareness of its own and rendered black text on a dark background.