### PR TITLE
fix: let super-admin sessions pass the auth guard

### DIFF
--- a/src/app/guard/auth.guard.ts
+++ b/src/app/guard/auth.guard.ts
@@ -14,7 +14,8 @@ const isAccessAllowed = async (
     return false;
   }
 
-  if (!inject(AuthServiceService).hasAnyRole(['manager', 'admin'])) {
+  const authService = inject(AuthServiceService);
+  if (!authService.hasAnyRole(['manager', 'admin']) && !authService.isSuperAdmin()) {
     inject(Router).navigate(['/forbidden']);
     return false;
   }


### PR DESCRIPTION
AuthGuard only checked for tenant-tier roles (manager/admin), so a super-admin token — which has neither, by design — got redirected to /forbidden on every route, including /system/academies.